### PR TITLE
Automatically display the next event

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -1,4 +1,34 @@
+- name: Mobile Dorset June
+  datetime: Wednesday, 8th June 2016 from 18:00
+  url: https://mobiledorset-june-2016.eventbrite.co.uk
+  location: EB 303 Bournemouth University Executive Business Centre
+
 - name: Mobile Dorset July
   datetime: Wednesday, 13th July 2016 from 18:00
   url: https://mobiledorset-july-2016.eventbrite.co.uk
+  location: EB 303 Bournemouth University Executive Business Centre
+
+- name: Mobile Dorset August
+  datetime: Wednesday, 10th August 2016 from 18:00
+  url: https://mobiledorset-august-2016.eventbrite.co.uk
+  location: EB 303 Bournemouth University Executive Business Centre
+
+- name: Mobile Dorset September
+  datetime: Wednesday, 14th September 2016 from 18:00
+  url: https://mobiledorset-september-2016.eventbrite.co.uk
+  location: EB 303 Bournemouth University Executive Business Centre
+
+- name: Mobile Dorset October
+  datetime: Wednesday, 12th October 2016 from 18:00
+  url: https://mobiledorset-october-2016.eventbrite.co.uk
+  location: EB 303 Bournemouth University Executive Business Centre
+
+- name: Mobile Dorset November
+  datetime: Wednesday, 9th November 2016 from 18:00
+  url: https://mobiledorset-november-2016.eventbrite.co.uk
+  location: EB 303 Bournemouth University Executive Business Centre
+
+- name: Mobile Dorset December
+  datetime: Wednesday, 14th December 2016 from 18:00
+  url: https://mobiledorset-december-2016.eventbrite.co.uk
   location: EB 303 Bournemouth University Executive Business Centre

--- a/index.html
+++ b/index.html
@@ -28,17 +28,23 @@ layout: default
 </div>
 <!-- Call to action -->
 <section class="call">
+  {% assign current_datetime_milliseconds = 'now' | date: '%s' %}
+
   {% for event in events %}
-    <div class="container">
-        <h1>{{event.datetime}}</h1>
-        <h1><small>{{event.location}}</small></h1>
-        <p class="text-center">
-            <a href="{{event.url}}" class="btn btn-default btn-lg center">
-            <span class="logo-eventbrite"></span>
-            <span>Grab Your Free "{{event.name}}" Ticket</span>
-            </a>
-        </p>
-    </div>
+    {% assign event_datetime_milliseconds = event.datetime | date: '%s' %}
+    {% if event_datetime_milliseconds >= current_datetime_milliseconds %}
+        <div class="container">
+            <h1>{{event.datetime}}</h1>
+            <h1><small>{{event.location}}</small></h1>
+            <p class="text-center">
+                <a href="{{event.url}}" class="btn btn-default btn-lg center">
+                <span class="logo-eventbrite"></span>
+                <span>Grab Your Free "{{event.name}}" Ticket</span>
+                </a>
+            </p>
+        </div>
+        {% break %}
+    {% endif %}
   {% endfor %}
 </section>
 <!-- Questions -->


### PR DESCRIPTION
- Automatically displays the next event on the home page
- Displays only the single next upcoming event that is the future

**Note:** Upon further testing it seems that the current time (milliseconds) used in this feature is only updated when it generates. This would mean that in order for this to work the site would have to have an commit to master in between events. Any suggestions for better solutions are more than welcome.